### PR TITLE
Added the ability to create Selenium proxy with protocols other than HTTP.

### DIFF
--- a/lib/browsermob/proxy/client.rb
+++ b/lib/browsermob/proxy/client.rb
@@ -34,9 +34,17 @@ module BrowserMob
         HAR::Archive.from_string @resource["har"].get
       end
 
-      def selenium_proxy
+      def selenium_proxy(*protocols)
         require 'selenium-webdriver' unless defined?(Selenium)
-        Selenium::WebDriver::Proxy.new(:http => "#{@host}:#{@port}")
+
+        protocols += [:http] if protocols.empty?
+        unless (protocols - [:http, :ssl, :ftp]).empty?
+          raise "Invalid protocol specified.  Must be one of: :http, :ssl, or :ftp."
+        end
+
+        proxy_mapping = {}
+        protocols.each { |proto| proxy_mapping[proto] = "#{@host}:#{@port}" }
+        Selenium::WebDriver::Proxy.new(proxy_mapping)
       end
 
       def whitelist(regexp, status_code)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -102,6 +102,38 @@ module BrowserMob
 
         client.headers(:foo => "bar")
       end
+
+      context "#selenium_proxy" do
+        it "defaults to HTTP proxy only" do
+          proxy = client.selenium_proxy
+
+          proxy.http.should == "#{client.host}:#{client.port}"
+          proxy.ssl.should be_nil
+          proxy.ftp.should be_nil
+        end
+
+        it "allows multiple protocols" do
+          proxy = client.selenium_proxy(:http, :ssl)
+
+          proxy.http.should == "#{client.host}:#{client.port}"
+          proxy.ssl.should == "#{client.host}:#{client.port}"
+          proxy.ftp.should be_nil
+        end
+
+        it "allows disabling HTTP proxy" do
+          proxy = client.selenium_proxy(:ssl)
+
+          proxy.ssl.should == "#{client.host}:#{client.port}"
+          proxy.http.should be_nil
+          proxy.ftp.should be_nil
+        end
+
+        it "raises an error when a bad protocol is used" do
+          lambda {
+            client.selenium_proxy(:htp)
+          }.should raise_error
+        end
+      end
     end
 
   end


### PR DESCRIPTION
I added the ability to specify protocols to use for proxy with some data validation.  An alternative is to always do HTTP and SSL like the Java BMP class does.  It feels kludgey because I wanted to use varargs with a default value.  We can change that to match whatever style you prefer.
