### PR TITLE
Add support for remapping DNS hosts

### DIFF
--- a/lib/browsermob/proxy/client.rb
+++ b/lib/browsermob/proxy/client.rb
@@ -90,6 +90,16 @@ module BrowserMob
         @resource["auth/basic/#{domain}"].post data.to_json, :content_type => "application/json"
       end
 
+      ##
+      # Override normal DNS lookups (remap the given hosts with the associated IP address).
+      # Each invocation of the method will add given hosts to existing BrowserMob's DNS cache
+      # instead of overriding it.
+      # @example remap_dns_hosts('example.com' => '1.2.3.4')
+      # @param hash [Hash] a hash with domains as keys and IPs as values
+      def remap_dns_hosts(hash)
+        @resource['hosts'].post hash.to_json, content_type: 'application/json'
+      end
+
       LIMITS = {
         :upstream_kbps   => 'upstreamKbps',
         :downstream_kbps => 'downstreamKbps',

--- a/spec/e2e/selenium_spec.rb
+++ b/spec/e2e/selenium_spec.rb
@@ -57,4 +57,13 @@ describe "Proxy + WebDriver" do
     proxy.limit(:downstream_kbps => 100, :upstream_kbps => 100, :latency => 2)
   end
 
+  it 'should remap given DNS hosts' do
+    host = '1.2.3.4'
+    proxy.remap_dns_hosts(host => '127.0.0.2')
+    uri = URI(url_for('1.html'))
+    uri.host = host
+    driver.get uri
+    wait.until { driver.title == '1' }
+    driver.find_element(:link_text => "2").click
+  end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -17,7 +17,8 @@ module BrowserMob
           "blacklist"            => double("resource[blacklist]"),
           "limit"                => double("resource[limit]"),
           "headers"              => double("resource[headers]"),
-          "auth/basic/#{DOMAIN}" => double("resource[auth/basic/#{DOMAIN}]")
+          "auth/basic/#{DOMAIN}" => double("resource[auth/basic/#{DOMAIN}]"),
+          "hosts"                => double("resource[hosts]")
         }.each do |path, mock|
           resource.stub(:[]).with(path).and_return(mock)
         end
@@ -135,6 +136,13 @@ module BrowserMob
         resource["auth/basic/#{DOMAIN}"].should_receive(:post).with(%({"username":"#{user}","password":"#{password}"}), :content_type => "application/json")
 
         client.basic_authentication(DOMAIN, user, password)
+      end
+
+      it 'sets mapped dns hosts' do
+        resource['hosts'].should_receive(:post).with(%({"#{DOMAIN}":"1.2.3.4"}),
+                                                     :content_type => "application/json")
+
+        client.remap_dns_hosts(DOMAIN => '1.2.3.4')
       end
 
       context "#selenium_proxy" do


### PR DESCRIPTION
I tried to write a Selenium spec but it didn't work for some reason:

``` ruby
it 'should remap given DNS hosts' do
  proxy.remap_dns_hosts('foo.newrelic.com' => '173.194.70.113')
  driver.get('foo.newrelic.com') # => NS_ERROR_MALFORMED_URI
end
```

It doesn't remap a DNS hosts though I believe it should.
