### PR TITLE
Add support for remapping DNS hosts

### DIFF
--- a/lib/browsermob/proxy/client.rb
+++ b/lib/browsermob/proxy/client.rb
@@ -101,6 +101,20 @@ module BrowserMob
         @resource["auth/basic/#{domain}"].post data.to_json, :content_type => "application/json"
       end
 
+      #
+      # Override normal DNS lookups (remap the given hosts with the associated IP address).
+      #
+      # Each invocation of the method will add given hosts to existing BrowserMob's DNS cache
+      # instead of overriding it.
+      #
+      # @example remap_dns_hosts('example.com' => '1.2.3.4')
+      # @param hash [Hash] a hash with domains as keys and IPs as values
+      #
+
+      def remap_dns_hosts(hash)
+        @resource['hosts'].post hash.to_json, :content_type => 'application/json'
+      end
+
       LIMITS = {
         :upstream_kbps   => 'upstreamKbps',
         :downstream_kbps => 'downstreamKbps',

--- a/spec/e2e/selenium_spec.rb
+++ b/spec/e2e/selenium_spec.rb
@@ -88,4 +88,12 @@ describe "Proxy + WebDriver" do
     proxy.limit(:downstream_kbps => 100, :upstream_kbps => 100, :latency => 2)
   end
 
+  it 'should remap given DNS hosts' do
+    proxy.remap_dns_hosts('plus.google.com' => '127.0.0.2')
+    uri = URI(url_for('1.html'))
+    uri.host = 'plus.google.com'
+    driver.get uri
+    wait.until { driver.title == '1' }
+  end
+
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -17,7 +17,8 @@ module BrowserMob
           "blacklist"            => double("resource[blacklist]"),
           "limit"                => double("resource[limit]"),
           "headers"              => double("resource[headers]"),
-          "auth/basic/#{DOMAIN}" => double("resource[auth/basic/#{DOMAIN}]")
+          "auth/basic/#{DOMAIN}" => double("resource[auth/basic/#{DOMAIN}]"),
+          "hosts"                => double("resource[hosts]")
         }.each do |path, mock|
           resource.stub(:[]).with(path).and_return(mock)
         end
@@ -151,6 +152,13 @@ module BrowserMob
         resource["auth/basic/#{DOMAIN}"].should_receive(:post).with(%({"username":"#{user}","password":"#{password}"}), :content_type => "application/json")
 
         client.basic_authentication(DOMAIN, user, password)
+      end
+
+      it 'sets mapped dns hosts' do
+        resource['hosts'].should_receive(:post).with(%({"#{DOMAIN}":"1.2.3.4"}),
+                                                     :content_type => "application/json")
+
+        client.remap_dns_hosts(DOMAIN => '1.2.3.4')
       end
 
       context "#selenium_proxy" do


### PR DESCRIPTION
This is the same pull request as https://github.com/jarib/browsermob-proxy-rb/pull/10
The only change is change from '1.2.3.4' to 'plus.google.com' in spec.

For some reason it works with '1.2.3.4', 'google.com', 'plus.google.com' but doesn't work with 'example.com', 'test.example.com', 'plus.example.com'
