### PR TITLE
Add args to create_proxy

### DIFF
--- a/lib/browsermob/proxy/client.rb
+++ b/lib/browsermob/proxy/client.rb
@@ -4,7 +4,7 @@ module BrowserMob
     class Client
       attr_reader :host, :port
 
-      def self.from(server_url, port = nil)
+      def self.from(server_url, port = nil, args={})
         # ActiveSupport may define Object#load, so we can't use MultiJson.respond_to? here.
         sm = MultiJson.singleton_methods.map { |e| e.to_sym }
         decode_method = sm.include?(:load) ? :load : :decode
@@ -13,7 +13,7 @@ module BrowserMob
         new_proxy_url.query = "port=#{port}" if port
 
         port = MultiJson.send(decode_method,
-          RestClient.post(new_proxy_url.to_s, '')
+          RestClient.post(new_proxy_url.to_s, args)
         ).fetch('port')
 
         uri = URI.parse(File.join(server_url, "proxy", port.to_s))

--- a/lib/browsermob/proxy/server.rb
+++ b/lib/browsermob/proxy/server.rb
@@ -43,8 +43,8 @@ module BrowserMob
         "http://localhost:#{port}"
       end
 
-      def create_proxy(port = nil)
-        Client.from url, port
+      def create_proxy(port = nil, args={})
+        Client.from url, port, args
       end
 
       def stop


### PR DESCRIPTION
Add the ability to send **args** to the POST method.

This enables the ability to set :trustAllServers => true.

Sample usage from ruby class:

@proxy_binary.create_proxy(80, { :trustAllServers => true })