### PR TITLE
Loosen version constraint for childprocess dependency

### DIFF
--- a/browsermob-proxy.gemspec
+++ b/browsermob-proxy.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "browsermob-proxy-rb"
 
   s.add_runtime_dependency "rest-client"
-  s.add_runtime_dependency "childprocess", "~> 0.5"
+  s.add_runtime_dependency "childprocess", ">= 0.5", "< 4.0"
   s.add_runtime_dependency "multi_json", "~> 1.0"
   s.add_runtime_dependency "har"
 


### PR DESCRIPTION
I have an application that uses `childprocess (= 3.0.0)`. Trying to introduce `browsermob-proxy-rb (~> 0.3.1)` to that project produces a conflict because `browsermob-proxy-rb` declares a dependency on `childprocess (~> 0.5)`. To resolve the conflict, I can downgrade `childprocess`, but I'd prefer not to. This project appears to be compatible with all versions of `childprocess` from 0.5 to 3.0.0, so this change just loosens the version constraint in the `gemspec`.

```
Resolving dependencies...
Bundler could not find compatible versions for gem "childprocess":
  In snapshot (Gemfile.lock):
    childprocess (= 3.0.0)

  In Gemfile:
    browsermob-proxy (~> 0.3.1) was resolved to 0.3.1, which depends on
      childprocess (~> 0.5)

    webdrivers was resolved to 4.2.0, which depends on
      selenium-webdriver (>= 3.0, < 4.0) was resolved to 3.142.7, which depends on
        childprocess (>= 0.5, < 4.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

If I remove the constraint in my `Gemfile` that I want the latest version of `browsermob-proxy-rb`, `bundler` installs version 0.1.7 since that version had no constraint at all on the `childprocess` version.  This is similarly undesirable.

https://github.com/browserup/browsermob-proxy-rb/blob/aa7e41fd3a12dbee0b607fe0bc55d95543dce932/browsermob-proxy.gemspec#L19